### PR TITLE
DRF API 구현 완료

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,14 +139,53 @@ DATABASE_PORT=3306
 - **다음 작업**: core/models.py에 HACCP 8개 모델 구현
 - **브랜치**: feature/django-backend-setup (PR 대기)
 
-### 2025-09-01: HACCP 모델 구현 완료
+### 2025-09-01: HACCP 모델 구현 완료 ✅
 
 - models/ 패키지 구조로 8개 모델 파일 분리 구현
 - User, Supplier, RawMaterial, MaterialLot, FinishedProduct, ProductionOrder, CCP, CCPLog
 - Django Admin 인터페이스 완비 (CCPLog는 불변 데이터로 수정/삭제 불가)
 - 시드 데이터 management command 구현 (admin 계정 자동 생성 포함)
-- **현재 상태**: 모든 HACCP 모델 구현 완료, 원클릭 테스트 환경 구축
-- **브랜치**: feature/haccp-models (작업 중)
+- **상태**: PR #2 머지 완료, main 브랜치 반영됨
+- **다음 작업**: DRF API 구현 (Serializers, ViewSets, 권한 시스템)
+
+### 2025-09-01: DRF API 구현 완료 ✅
+
+- **Serializers 구현**: 8개 모델별 CRUD 분리 구조
+  - UserSerializer (조회/생성/수정용 분리)
+  - SupplierSerializer, RawMaterialSerializer, MaterialLotSerializer
+  - FinishedProductSerializer, ProductionOrderSerializer
+  - CCPSerializer, CCPLogSerializer (불변 로그 처리)
+- **ViewSets 구현**: REST API 엔드포인트 및 커스텀 액션
+  - 역할별 권한 필터링 (admin, quality_manager, operator 등)
+  - 통계/대시보드 API (/statistics, /dashboard 등)
+  - HACCP 전용 기능 (/compliance-report, /critical-alerts)
+- **URL 라우팅**: DRF Router로 자동 URL 생성
+- **의존성 추가**: django-filter 패키지 및 설정
+- **브라우저 테스트**: API 구조 및 권한 시스템 검증 완료
+- **상태**: feature/api-implementation 브랜치, PR 생성 준비
+- **다음 작업**: JWT 토큰 엔드포인트 추가, 권한 시스템 고도화
+
+### 다음 세션 시작 가이드
+
+**현재 완료된 것:**
+- ✅ Django 백엔드 초기 설정
+- ✅ HACCP 모델 8개 구현
+- ✅ Django Admin + 시드 데이터
+- ✅ DRF API 구현 (Serializers + ViewSets)
+- ✅ URL 라우팅 및 권한 시스템
+
+**다음 세션에서 해야 할 것:**
+1. PR 리뷰 및 머지 (feature/api-implementation → main)
+2. `git checkout -b feature/jwt-auth` (JWT 토큰 엔드포인트 추가)
+3. Service Layer 구현 (비즈니스 로직 분리)
+4. 권한 시스템 고도화 (role-based permissions)
+5. API 문서화 (drf-spectacular)
+
+**참고 명령어:**
+- 테스트 환경 구축: `python manage.py seed_data --clear`
+- 서버 실행: `python manage.py runserver`
+- Admin 접속: http://localhost:8000/admin/ (admin/admin123)
+- API 테스트: http://localhost:8000/api/ (JWT 토큰 필요)
 
 ### 개발 노하우 메모
 

--- a/backend/core/serializers/__init__.py
+++ b/backend/core/serializers/__init__.py
@@ -1,0 +1,21 @@
+from .user_serializers import UserSerializer, UserCreateSerializer, UserUpdateSerializer
+from .supplier_serializers import SupplierSerializer, SupplierCreateSerializer, SupplierUpdateSerializer  
+from .raw_material_serializers import RawMaterialSerializer, MaterialLotSerializer, MaterialLotCreateSerializer
+from .product_serializers import FinishedProductSerializer, FinishedProductCreateSerializer, FinishedProductUpdateSerializer
+from .production_serializers import ProductionOrderSerializer, ProductionOrderCreateSerializer, ProductionOrderUpdateSerializer
+from .haccp_serializers import CCPSerializer, CCPCreateSerializer, CCPLogSerializer, CCPLogCreateSerializer, CCPLogUpdateSerializer
+
+__all__ = [
+    'UserSerializer',
+    'UserCreateSerializer', 
+    'UserUpdateSerializer',
+    'SupplierSerializer',
+    'SupplierCreateSerializer',
+    'SupplierUpdateSerializer',
+    'RawMaterialSerializer',
+    'MaterialLotSerializer', 
+    'FinishedProductSerializer',
+    'ProductionOrderSerializer',
+    'CCPSerializer',
+    'CCPLogSerializer',
+]

--- a/backend/core/serializers/haccp_serializers.py
+++ b/backend/core/serializers/haccp_serializers.py
@@ -1,0 +1,274 @@
+from rest_framework import serializers
+from django.utils import timezone
+from core.models import CCP, CCPLog
+from .user_serializers import UserSerializer
+from .product_serializers import FinishedProductSerializer
+from .production_serializers import ProductionOrderSerializer
+
+
+class CCPSerializer(serializers.ModelSerializer):
+    """중요 관리점(CCP) 조회용 Serializer"""
+    
+    finished_product = FinishedProductSerializer(read_only=True)
+    created_by = UserSerializer(read_only=True)
+    
+    # 통계 정보
+    total_logs = serializers.SerializerMethodField()
+    out_of_limits_count = serializers.SerializerMethodField()
+    compliance_rate = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = CCP
+        fields = [
+            'id', 'name', 'code', 'ccp_type', 'description', 'process_step',
+            'critical_limit_min', 'critical_limit_max', 'monitoring_frequency',
+            'corrective_action', 'responsible_person', 'monitoring_method',
+            'verification_method', 'record_keeping', 'finished_product', 'is_active',
+            'total_logs', 'out_of_limits_count', 'compliance_rate',
+            'created_at', 'updated_at', 'created_by'
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at', 'created_by']
+    
+    def get_total_logs(self, obj):
+        """총 로그 수"""
+        return obj.logs.count()
+    
+    def get_out_of_limits_count(self, obj):
+        """기준 이탈 로그 수 (최근 30일)"""
+        from datetime import timedelta
+        thirty_days_ago = timezone.now() - timedelta(days=30)
+        return obj.logs.filter(
+            measured_at__gte=thirty_days_ago,
+            status='out_of_limits'
+        ).count()
+    
+    def get_compliance_rate(self, obj):
+        """규정 준수율 (최근 30일, 백분율)"""
+        from datetime import timedelta
+        thirty_days_ago = timezone.now() - timedelta(days=30)
+        
+        total_logs = obj.logs.filter(measured_at__gte=thirty_days_ago).count()
+        if total_logs == 0:
+            return None
+            
+        within_limits_count = obj.logs.filter(
+            measured_at__gte=thirty_days_ago,
+            status='within_limits'
+        ).count()
+        
+        return round((within_limits_count / total_logs) * 100, 2)
+
+
+class CCPCreateSerializer(serializers.ModelSerializer):
+    """CCP 생성용 Serializer"""
+    
+    finished_product_id = serializers.UUIDField(write_only=True, required=False, allow_null=True)
+    
+    class Meta:
+        model = CCP
+        fields = [
+            'name', 'code', 'ccp_type', 'description', 'process_step',
+            'critical_limit_min', 'critical_limit_max', 'monitoring_frequency',
+            'corrective_action', 'responsible_person', 'monitoring_method',
+            'verification_method', 'record_keeping', 'finished_product_id', 'is_active'
+        ]
+        
+    def validate_code(self, value):
+        if CCP.objects.filter(code=value).exists():
+            raise serializers.ValidationError("이미 존재하는 CCP 코드입니다.")
+        return value
+    
+    def validate(self, attrs):
+        critical_min = attrs.get('critical_limit_min')
+        critical_max = attrs.get('critical_limit_max')
+        ccp_type = attrs.get('ccp_type')
+        
+        # 온도, pH, 압력, 중량 타입은 수치 한계 필요
+        numeric_types = ['temperature', 'ph', 'pressure', 'weight']
+        if ccp_type in numeric_types:
+            if critical_min is None and critical_max is None:
+                raise serializers.ValidationError(
+                    f"{ccp_type} 타입의 CCP는 최소값 또는 최대값 중 하나는 설정해야 합니다."
+                )
+                
+        # 최소값이 최대값보다 클 수 없음
+        if critical_min is not None and critical_max is not None:
+            if critical_min > critical_max:
+                raise serializers.ValidationError({
+                    'critical_limit_min': '최소 한계값은 최대 한계값보다 작아야 합니다.'
+                })
+                
+        return attrs
+    
+    def create(self, validated_data):
+        finished_product_id = validated_data.pop('finished_product_id', None)
+        
+        if finished_product_id:
+            validated_data['finished_product_id'] = finished_product_id
+            
+        request = self.context.get('request')
+        if request and hasattr(request, 'user'):
+            validated_data['created_by'] = request.user
+            
+        return super().create(validated_data)
+
+
+class CCPLogSerializer(serializers.ModelSerializer):
+    """CCP 모니터링 로그 조회용 Serializer"""
+    
+    ccp = CCPSerializer(read_only=True)
+    production_order = ProductionOrderSerializer(read_only=True)
+    created_by = UserSerializer(read_only=True)
+    corrective_action_by = UserSerializer(read_only=True)
+    verified_by = UserSerializer(read_only=True)
+    
+    # 계산 필드
+    deviation_percentage = serializers.SerializerMethodField()
+    time_since_measurement = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = CCPLog
+        fields = [
+            'id', 'ccp', 'production_order', 'measured_value', 'unit', 'measured_at',
+            'status', 'is_within_limits', 'deviation_notes', 'corrective_action_taken',
+            'corrective_action_by', 'verified_by', 'verification_date',
+            'measurement_device', 'environmental_conditions', 'deviation_percentage',
+            'time_since_measurement', 'created_at', 'created_by'
+        ]
+        read_only_fields = ['id', 'created_at', 'created_by', 'is_within_limits', 'status']
+    
+    def get_deviation_percentage(self, obj):
+        """한계 기준 대비 편차율 계산"""
+        if obj.status == 'within_limits':
+            return 0
+            
+        ccp = obj.ccp
+        measured = float(obj.measured_value)
+        
+        if ccp.critical_limit_min is not None and measured < float(ccp.critical_limit_min):
+            deviation = ((float(ccp.critical_limit_min) - measured) / float(ccp.critical_limit_min)) * 100
+            return round(-deviation, 2)  # 음수로 표시 (하한값 미달)
+        elif ccp.critical_limit_max is not None and measured > float(ccp.critical_limit_max):
+            deviation = ((measured - float(ccp.critical_limit_max)) / float(ccp.critical_limit_max)) * 100
+            return round(deviation, 2)  # 양수로 표시 (상한값 초과)
+            
+        return 0
+    
+    def get_time_since_measurement(self, obj):
+        """측정 후 경과시간 (시간 단위)"""
+        time_diff = timezone.now() - obj.measured_at
+        return round(time_diff.total_seconds() / 3600, 2)
+
+
+class CCPLogCreateSerializer(serializers.ModelSerializer):
+    """CCP 로그 생성용 Serializer - 불변 데이터이므로 생성만 가능"""
+    
+    ccp_id = serializers.UUIDField(write_only=True)
+    production_order_id = serializers.UUIDField(write_only=True, required=False, allow_null=True)
+    
+    class Meta:
+        model = CCPLog
+        fields = [
+            'ccp_id', 'production_order_id', 'measured_value', 'unit', 'measured_at',
+            'deviation_notes', 'corrective_action_taken', 'measurement_device',
+            'environmental_conditions'
+        ]
+        
+    def validate_measured_value(self, value):
+        if value is None:
+            raise serializers.ValidationError("측정값은 필수입니다.")
+        return value
+    
+    def validate(self, attrs):
+        measured_at = attrs.get('measured_at')
+        
+        # 미래 시간 체크
+        if measured_at and measured_at > timezone.now():
+            raise serializers.ValidationError({
+                'measured_at': '측정 시간은 현재 시간보다 늦을 수 없습니다.'
+            })
+            
+        # CCP 존재 확인
+        ccp_id = attrs.get('ccp_id')
+        if ccp_id:
+            try:
+                ccp = CCP.objects.get(id=ccp_id, is_active=True)
+                attrs['ccp_instance'] = ccp  # 나중에 사용하기 위해 저장
+            except CCP.DoesNotExist:
+                raise serializers.ValidationError({
+                    'ccp_id': '존재하지 않거나 비활성화된 CCP입니다.'
+                })
+                
+        return attrs
+    
+    def create(self, validated_data):
+        ccp_id = validated_data.pop('ccp_id')
+        production_order_id = validated_data.pop('production_order_id', None)
+        ccp_instance = validated_data.pop('ccp_instance', None)
+        
+        validated_data['ccp_id'] = ccp_id
+        if production_order_id:
+            validated_data['production_order_id'] = production_order_id
+            
+        request = self.context.get('request')
+        if request and hasattr(request, 'user'):
+            validated_data['created_by'] = request.user
+            
+        # CCP 모델의 save() 메서드가 자동으로 is_within_limits, status 설정
+        return super().create(validated_data)
+
+
+class CCPLogUpdateSerializer(serializers.ModelSerializer):
+    """CCP 로그 수정용 Serializer - 개선조치 정보만 수정 가능"""
+    
+    corrective_action_by_id = serializers.UUIDField(write_only=True, required=False, allow_null=True)
+    verified_by_id = serializers.UUIDField(write_only=True, required=False, allow_null=True)
+    
+    class Meta:
+        model = CCPLog
+        fields = [
+            'corrective_action_taken', 'corrective_action_by_id',
+            'verified_by_id', 'verification_date'
+        ]
+        
+    def validate(self, attrs):
+        # 개선조치 정보는 기준 이탈 시에만 입력 가능
+        if self.instance.status == 'within_limits':
+            if attrs.get('corrective_action_taken'):
+                raise serializers.ValidationError(
+                    "기준 내 측정값에는 개선조치를 입력할 수 없습니다."
+                )
+                
+        # 검증자와 검증일자는 세트로 입력
+        verified_by_id = attrs.get('verified_by_id')
+        verification_date = attrs.get('verification_date')
+        
+        if verified_by_id and not verification_date:
+            raise serializers.ValidationError({
+                'verification_date': '검증자를 지정할 때는 검증일자도 입력해야 합니다.'
+            })
+        elif verification_date and not verified_by_id:
+            raise serializers.ValidationError({
+                'verified_by_id': '검증일자를 입력할 때는 검증자도 지정해야 합니다.'
+            })
+            
+        return attrs
+    
+    def update(self, instance, validated_data):
+        corrective_action_by_id = validated_data.pop('corrective_action_by_id', None)
+        verified_by_id = validated_data.pop('verified_by_id', None)
+        
+        if 'corrective_action_by_id' in self.initial_data:
+            instance.corrective_action_by_id = corrective_action_by_id
+        if 'verified_by_id' in self.initial_data:
+            instance.verified_by_id = verified_by_id
+            
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+            
+        # 개선조치가 완료되면 상태 업데이트
+        if instance.corrective_action_taken and instance.status == 'out_of_limits':
+            instance.status = 'corrective_action'
+            
+        instance.save()
+        return instance

--- a/backend/core/serializers/product_serializers.py
+++ b/backend/core/serializers/product_serializers.py
@@ -1,0 +1,144 @@
+from rest_framework import serializers
+from core.models import FinishedProduct
+from .user_serializers import UserSerializer
+
+
+class FinishedProductSerializer(serializers.ModelSerializer):
+    """완제품 조회용 Serializer"""
+    
+    created_by = UserSerializer(read_only=True)
+    
+    class Meta:
+        model = FinishedProduct
+        fields = [
+            'id', 'name', 'code', 'description', 'version', 'shelf_life_days',
+            'storage_temp_min', 'storage_temp_max', 'net_weight', 'packaging_type',
+            'allergen_info', 'nutrition_facts', 'is_active',
+            'created_at', 'updated_at', 'created_by'
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at', 'created_by']
+
+
+class FinishedProductCreateSerializer(serializers.ModelSerializer):
+    """완제품 생성용 Serializer"""
+    
+    class Meta:
+        model = FinishedProduct
+        fields = [
+            'name', 'code', 'description', 'version', 'shelf_life_days',
+            'storage_temp_min', 'storage_temp_max', 'net_weight', 'packaging_type',
+            'allergen_info', 'nutrition_facts', 'is_active'
+        ]
+        
+    def validate_code(self, value):
+        if FinishedProduct.objects.filter(code=value).exists():
+            raise serializers.ValidationError("이미 존재하는 제품 코드입니다.")
+        return value
+    
+    def validate_shelf_life_days(self, value):
+        if value <= 0:
+            raise serializers.ValidationError("유통기한은 0일보다 커야 합니다.")
+        return value
+    
+    def validate_net_weight(self, value):
+        if value <= 0:
+            raise serializers.ValidationError("순중량은 0보다 커야 합니다.")
+        return value
+    
+    def validate(self, attrs):
+        temp_min = attrs.get('storage_temp_min')
+        temp_max = attrs.get('storage_temp_max')
+        
+        if temp_min is not None and temp_max is not None:
+            if temp_min > temp_max:
+                raise serializers.ValidationError({
+                    'storage_temp_min': '최소 보관온도는 최대 보관온도보다 낮아야 합니다.'
+                })
+        return attrs
+    
+    def validate_nutrition_facts(self, value):
+        """영양성분표 JSON 형식 검증"""
+        if value is not None:
+            required_keys = ['calories', 'protein', 'fat', 'carbohydrates', 'sodium']
+            if not isinstance(value, dict):
+                raise serializers.ValidationError("영양성분표는 JSON 객체 형태여야 합니다.")
+            
+            missing_keys = [key for key in required_keys if key not in value]
+            if missing_keys:
+                raise serializers.ValidationError(
+                    f"필수 영양성분 정보가 누락되었습니다: {', '.join(missing_keys)}"
+                )
+                
+            # 숫자값 검증
+            for key, val in value.items():
+                if key in required_keys and not isinstance(val, (int, float)):
+                    raise serializers.ValidationError(f"{key}는 숫자값이어야 합니다.")
+                    
+        return value
+    
+    def create(self, validated_data):
+        request = self.context.get('request')
+        if request and hasattr(request, 'user'):
+            validated_data['created_by'] = request.user
+        return super().create(validated_data)
+
+
+class FinishedProductUpdateSerializer(serializers.ModelSerializer):
+    """완제품 수정용 Serializer"""
+    
+    class Meta:
+        model = FinishedProduct
+        fields = [
+            'name', 'description', 'version', 'shelf_life_days',
+            'storage_temp_min', 'storage_temp_max', 'net_weight', 'packaging_type',
+            'allergen_info', 'nutrition_facts', 'is_active'
+        ]
+        
+    def validate_code(self, value):
+        """수정시 자기 자신 제외하고 코드 중복 검증"""
+        if self.instance and self.instance.code == value:
+            return value
+        if FinishedProduct.objects.filter(code=value).exists():
+            raise serializers.ValidationError("이미 존재하는 제품 코드입니다.")
+        return value
+    
+    def validate_shelf_life_days(self, value):
+        if value <= 0:
+            raise serializers.ValidationError("유통기한은 0일보다 커야 합니다.")
+        return value
+    
+    def validate_net_weight(self, value):
+        if value <= 0:
+            raise serializers.ValidationError("순중량은 0보다 커야 합니다.")
+        return value
+    
+    def validate(self, attrs):
+        temp_min = attrs.get('storage_temp_min')
+        temp_max = attrs.get('storage_temp_max')
+        
+        if temp_min is not None and temp_max is not None:
+            if temp_min > temp_max:
+                raise serializers.ValidationError({
+                    'storage_temp_min': '최소 보관온도는 최대 보관온도보다 낮아야 합니다.'
+                })
+        return attrs
+    
+    def validate_nutrition_facts(self, value):
+        """영양성분표 JSON 형식 검증"""
+        if value is not None:
+            required_keys = ['calories', 'protein', 'fat', 'carbohydrates', 'sodium']
+            if not isinstance(value, dict):
+                raise serializers.ValidationError("영양성분표는 JSON 객체 형태여야 합니다.")
+            
+            missing_keys = [key for key in required_keys if key not in value]
+            if missing_keys:
+                raise serializers.ValidationError(
+                    f"필수 영양성분 정보가 누락되었습니다: {', '.join(missing_keys)}"
+                )
+                
+            # 숫자값 검증
+            for key, val in value.items():
+                if key in required_keys and not isinstance(val, (int, float)):
+                    raise serializers.ValidationError(f"{key}는 숫자값이어야 합니다.")
+                    
+        return value

--- a/backend/core/serializers/production_serializers.py
+++ b/backend/core/serializers/production_serializers.py
@@ -1,0 +1,191 @@
+from rest_framework import serializers
+from django.utils import timezone
+from core.models import ProductionOrder
+from .user_serializers import UserSerializer
+from .product_serializers import FinishedProductSerializer
+
+
+class ProductionOrderSerializer(serializers.ModelSerializer):
+    """생산오더 조회용 Serializer"""
+    
+    finished_product = FinishedProductSerializer(read_only=True)
+    assigned_operator = UserSerializer(read_only=True)
+    created_by = UserSerializer(read_only=True)
+    
+    # 계산 필드
+    completion_rate = serializers.SerializerMethodField()
+    is_overdue = serializers.SerializerMethodField()
+    duration_planned = serializers.SerializerMethodField()
+    duration_actual = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = ProductionOrder
+        fields = [
+            'id', 'order_number', 'finished_product', 'planned_quantity', 'produced_quantity',
+            'planned_start_date', 'planned_end_date', 'actual_start_date', 'actual_end_date',
+            'status', 'priority', 'notes', 'assigned_operator', 'completion_rate', 
+            'is_overdue', 'duration_planned', 'duration_actual',
+            'created_at', 'updated_at', 'created_by'
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at', 'created_by']
+    
+    def get_completion_rate(self, obj):
+        """생산 완료율 계산"""
+        if obj.planned_quantity == 0:
+            return 0
+        return round((obj.produced_quantity / obj.planned_quantity) * 100, 2)
+    
+    def get_is_overdue(self, obj):
+        """일정 지연 여부"""
+        if obj.status in ['completed', 'cancelled']:
+            return False
+        return timezone.now() > obj.planned_end_date
+    
+    def get_duration_planned(self, obj):
+        """계획 소요시간 (시간 단위)"""
+        if obj.planned_start_date and obj.planned_end_date:
+            duration = obj.planned_end_date - obj.planned_start_date
+            return round(duration.total_seconds() / 3600, 2)
+        return None
+    
+    def get_duration_actual(self, obj):
+        """실제 소요시간 (시간 단위)"""
+        if obj.actual_start_date and obj.actual_end_date:
+            duration = obj.actual_end_date - obj.actual_start_date
+            return round(duration.total_seconds() / 3600, 2)
+        return None
+
+
+class ProductionOrderCreateSerializer(serializers.ModelSerializer):
+    """생산오더 생성용 Serializer"""
+    
+    finished_product_id = serializers.UUIDField(write_only=True)
+    assigned_operator_id = serializers.UUIDField(write_only=True, required=False, allow_null=True)
+    
+    class Meta:
+        model = ProductionOrder
+        fields = [
+            'order_number', 'finished_product_id', 'planned_quantity',
+            'planned_start_date', 'planned_end_date', 'status', 'priority',
+            'notes', 'assigned_operator_id'
+        ]
+        
+    def validate_order_number(self, value):
+        if ProductionOrder.objects.filter(order_number=value).exists():
+            raise serializers.ValidationError("이미 존재하는 주문번호입니다.")
+        return value
+    
+    def validate_planned_quantity(self, value):
+        if value <= 0:
+            raise serializers.ValidationError("계획 수량은 0보다 커야 합니다.")
+        return value
+    
+    def validate(self, attrs):
+        planned_start = attrs.get('planned_start_date')
+        planned_end = attrs.get('planned_end_date')
+        
+        if planned_start and planned_end:
+            if planned_start >= planned_end:
+                raise serializers.ValidationError({
+                    'planned_end_date': '계획 종료일은 시작일보다 늦어야 합니다.'
+                })
+                
+            # 과거 날짜 체크
+            if planned_start < timezone.now():
+                raise serializers.ValidationError({
+                    'planned_start_date': '계획 시작일은 현재 시간 이후여야 합니다.'
+                })
+                
+        return attrs
+    
+    def create(self, validated_data):
+        finished_product_id = validated_data.pop('finished_product_id')
+        assigned_operator_id = validated_data.pop('assigned_operator_id', None)
+        
+        validated_data['finished_product_id'] = finished_product_id
+        if assigned_operator_id:
+            validated_data['assigned_operator_id'] = assigned_operator_id
+            
+        request = self.context.get('request')
+        if request and hasattr(request, 'user'):
+            validated_data['created_by'] = request.user
+            
+        return super().create(validated_data)
+
+
+class ProductionOrderUpdateSerializer(serializers.ModelSerializer):
+    """생산오더 수정용 Serializer"""
+    
+    assigned_operator_id = serializers.UUIDField(write_only=True, required=False, allow_null=True)
+    
+    class Meta:
+        model = ProductionOrder
+        fields = [
+            'planned_quantity', 'produced_quantity', 'planned_start_date', 'planned_end_date',
+            'actual_start_date', 'actual_end_date', 'status', 'priority', 'notes',
+            'assigned_operator_id'
+        ]
+        
+    def validate_planned_quantity(self, value):
+        if value <= 0:
+            raise serializers.ValidationError("계획 수량은 0보다 커야 합니다.")
+        return value
+    
+    def validate_produced_quantity(self, value):
+        if value < 0:
+            raise serializers.ValidationError("생산 수량은 0 이상이어야 합니다.")
+        return value
+    
+    def validate(self, attrs):
+        planned_start = attrs.get('planned_start_date', self.instance.planned_start_date)
+        planned_end = attrs.get('planned_end_date', self.instance.planned_end_date)
+        actual_start = attrs.get('actual_start_date', self.instance.actual_start_date)
+        actual_end = attrs.get('actual_end_date', self.instance.actual_end_date)
+        status = attrs.get('status', self.instance.status)
+        
+        # 계획 날짜 검증
+        if planned_start and planned_end and planned_start >= planned_end:
+            raise serializers.ValidationError({
+                'planned_end_date': '계획 종료일은 시작일보다 늦어야 합니다.'
+            })
+        
+        # 실제 날짜 검증
+        if actual_start and actual_end and actual_start >= actual_end:
+            raise serializers.ValidationError({
+                'actual_end_date': '실제 종료일은 시작일보다 늦어야 합니다.'
+            })
+        
+        # 상태별 필수 필드 검증
+        if status == 'in_progress' and not actual_start:
+            if 'actual_start_date' not in attrs:
+                raise serializers.ValidationError({
+                    'actual_start_date': '생산중 상태에서는 실제 시작일이 필요합니다.'
+                })
+        
+        if status == 'completed':
+            if not actual_start or not actual_end:
+                missing_fields = []
+                if not actual_start and 'actual_start_date' not in attrs:
+                    missing_fields.append('actual_start_date')
+                if not actual_end and 'actual_end_date' not in attrs:
+                    missing_fields.append('actual_end_date')
+                
+                if missing_fields:
+                    raise serializers.ValidationError({
+                        field: '완료 상태에서는 실제 시작일과 종료일이 모두 필요합니다.'
+                        for field in missing_fields
+                    })
+                    
+        return attrs
+    
+    def update(self, instance, validated_data):
+        assigned_operator_id = validated_data.pop('assigned_operator_id', None)
+        
+        if 'assigned_operator_id' in self.initial_data:
+            instance.assigned_operator_id = assigned_operator_id
+            
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+            
+        instance.save()
+        return instance

--- a/backend/core/serializers/raw_material_serializers.py
+++ b/backend/core/serializers/raw_material_serializers.py
@@ -1,0 +1,166 @@
+from rest_framework import serializers
+from decimal import Decimal
+from core.models import RawMaterial, MaterialLot
+from .user_serializers import UserSerializer
+from .supplier_serializers import SupplierSerializer
+
+
+class RawMaterialSerializer(serializers.ModelSerializer):
+    """원자재 카탈로그 조회용 Serializer"""
+    
+    supplier = SupplierSerializer(read_only=True)
+    created_by = UserSerializer(read_only=True)
+    
+    class Meta:
+        model = RawMaterial
+        fields = [
+            'id', 'name', 'code', 'category', 'description', 'unit',
+            'storage_temp_min', 'storage_temp_max', 'shelf_life_days', 
+            'allergens', 'supplier', 'is_active',
+            'created_at', 'updated_at', 'created_by'
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at', 'created_by']
+
+
+class RawMaterialCreateSerializer(serializers.ModelSerializer):
+    """원자재 생성용 Serializer"""
+    
+    supplier_id = serializers.UUIDField(write_only=True)
+    
+    class Meta:
+        model = RawMaterial
+        fields = [
+            'name', 'code', 'category', 'description', 'unit',
+            'storage_temp_min', 'storage_temp_max', 'shelf_life_days',
+            'allergens', 'supplier_id', 'is_active'
+        ]
+        
+    def validate_code(self, value):
+        if RawMaterial.objects.filter(code=value).exists():
+            raise serializers.ValidationError("이미 존재하는 원자재 코드입니다.")
+        return value
+    
+    def validate(self, attrs):
+        temp_min = attrs.get('storage_temp_min')
+        temp_max = attrs.get('storage_temp_max')
+        
+        if temp_min is not None and temp_max is not None:
+            if temp_min > temp_max:
+                raise serializers.ValidationError({
+                    'storage_temp_min': '최소 온도는 최대 온도보다 낮아야 합니다.'
+                })
+        return attrs
+    
+    def create(self, validated_data):
+        supplier_id = validated_data.pop('supplier_id')
+        validated_data['supplier_id'] = supplier_id
+        
+        request = self.context.get('request')
+        if request and hasattr(request, 'user'):
+            validated_data['created_by'] = request.user
+            
+        return super().create(validated_data)
+
+
+class MaterialLotSerializer(serializers.ModelSerializer):
+    """원자재 로트 조회용 Serializer - 추적성 정보 포함"""
+    
+    raw_material = RawMaterialSerializer(read_only=True)
+    supplier = SupplierSerializer(read_only=True)
+    created_by = UserSerializer(read_only=True)
+    
+    # 계산 필드
+    quantity_used = serializers.SerializerMethodField()
+    usage_percentage = serializers.SerializerMethodField()
+    days_until_expiry = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = MaterialLot
+        fields = [
+            'id', 'lot_number', 'raw_material', 'supplier',
+            'received_date', 'expiry_date', 'quantity_received', 'quantity_current',
+            'quantity_used', 'usage_percentage', 'unit_price', 'status',
+            'quality_test_passed', 'quality_test_date', 'quality_test_notes',
+            'storage_location', 'temperature_at_receipt', 'days_until_expiry',
+            'created_at', 'updated_at', 'created_by'
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at', 'created_by']
+    
+    def get_quantity_used(self, obj):
+        """사용된 수량 계산"""
+        return obj.quantity_received - obj.quantity_current
+    
+    def get_usage_percentage(self, obj):
+        """사용률 계산"""
+        if obj.quantity_received == 0:
+            return 0
+        usage_rate = (obj.quantity_received - obj.quantity_current) / obj.quantity_received * 100
+        return round(float(usage_rate), 2)
+    
+    def get_days_until_expiry(self, obj):
+        """유통기한까지 남은 일수"""
+        if not obj.expiry_date:
+            return None
+        from datetime import date
+        days_diff = (obj.expiry_date - date.today()).days
+        return days_diff if days_diff >= 0 else 0
+
+
+class MaterialLotCreateSerializer(serializers.ModelSerializer):
+    """원자재 로트 생성용 Serializer"""
+    
+    raw_material_id = serializers.UUIDField(write_only=True)
+    supplier_id = serializers.UUIDField(write_only=True)
+    
+    class Meta:
+        model = MaterialLot
+        fields = [
+            'lot_number', 'raw_material_id', 'supplier_id', 
+            'received_date', 'expiry_date', 'quantity_received',
+            'unit_price', 'status', 'quality_test_passed', 
+            'quality_test_date', 'quality_test_notes',
+            'storage_location', 'temperature_at_receipt'
+        ]
+        
+    def validate_lot_number(self, value):
+        if MaterialLot.objects.filter(lot_number=value).exists():
+            raise serializers.ValidationError("이미 존재하는 로트 번호입니다.")
+        return value
+    
+    def validate_quantity_received(self, value):
+        if value <= 0:
+            raise serializers.ValidationError("입고 수량은 0보다 커야 합니다.")
+        return value
+    
+    def validate(self, attrs):
+        from datetime import date
+        
+        # 유통기한 검증
+        if attrs.get('expiry_date'):
+            if attrs['expiry_date'] <= date.today():
+                raise serializers.ValidationError({
+                    'expiry_date': '유통기한은 오늘 날짜 이후여야 합니다.'
+                })
+        
+        # 품질검사 날짜 검증
+        if attrs.get('quality_test_date') and attrs.get('received_date'):
+            if attrs['quality_test_date'].date() < attrs['received_date'].date():
+                raise serializers.ValidationError({
+                    'quality_test_date': '품질검사 날짜는 입고일 이후여야 합니다.'
+                })
+                
+        return attrs
+    
+    def create(self, validated_data):
+        raw_material_id = validated_data.pop('raw_material_id')
+        supplier_id = validated_data.pop('supplier_id')
+        
+        validated_data['raw_material_id'] = raw_material_id
+        validated_data['supplier_id'] = supplier_id
+        validated_data['quantity_current'] = validated_data['quantity_received']
+        
+        request = self.context.get('request')
+        if request and hasattr(request, 'user'):
+            validated_data['created_by'] = request.user
+            
+        return super().create(validated_data)

--- a/backend/core/serializers/supplier_serializers.py
+++ b/backend/core/serializers/supplier_serializers.py
@@ -1,0 +1,61 @@
+from rest_framework import serializers
+from core.models import Supplier
+from .user_serializers import UserSerializer
+
+
+class SupplierSerializer(serializers.ModelSerializer):
+    """공급업체 조회용 Serializer"""
+    
+    created_by = UserSerializer(read_only=True)
+    
+    class Meta:
+        model = Supplier
+        fields = [
+            'id', 'name', 'code', 'contact_person', 'email', 'phone', 
+            'address', 'certification', 'status', 
+            'created_at', 'updated_at', 'created_by'
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at', 'created_by']
+
+
+class SupplierCreateSerializer(serializers.ModelSerializer):
+    """공급업체 생성용 Serializer"""
+    
+    class Meta:
+        model = Supplier
+        fields = [
+            'name', 'code', 'contact_person', 'email', 'phone', 
+            'address', 'certification', 'status'
+        ]
+        
+    def validate_code(self, value):
+        """공급업체 코드 중복 검증"""
+        if Supplier.objects.filter(code=value).exists():
+            raise serializers.ValidationError("이미 존재하는 공급업체 코드입니다.")
+        return value
+    
+    def create(self, validated_data):
+        """생성자 정보 자동 설정"""
+        request = self.context.get('request')
+        if request and hasattr(request, 'user'):
+            validated_data['created_by'] = request.user
+        return super().create(validated_data)
+
+
+class SupplierUpdateSerializer(serializers.ModelSerializer):
+    """공급업체 수정용 Serializer"""
+    
+    class Meta:
+        model = Supplier
+        fields = [
+            'name', 'contact_person', 'email', 'phone', 
+            'address', 'certification', 'status'
+        ]
+        
+    def validate_code(self, value):
+        """수정시 자기 자신 제외하고 코드 중복 검증"""
+        if self.instance and self.instance.code == value:
+            return value
+        if Supplier.objects.filter(code=value).exists():
+            raise serializers.ValidationError("이미 존재하는 공급업체 코드입니다.")
+        return value

--- a/backend/core/serializers/user_serializers.py
+++ b/backend/core/serializers/user_serializers.py
@@ -1,0 +1,77 @@
+from rest_framework import serializers
+from django.contrib.auth.password_validation import validate_password
+from core.models import User
+
+
+class UserSerializer(serializers.ModelSerializer):
+    """사용자 조회용 Serializer - 비밀번호 제외"""
+    
+    class Meta:
+        model = User
+        fields = [
+            'id', 'username', 'email', 'first_name', 'last_name',
+            'role', 'employee_id', 'department', 'phone', 
+            'is_active', 'date_joined', 'created_at', 'updated_at'
+        ]
+        read_only_fields = ['id', 'date_joined', 'created_at', 'updated_at']
+
+
+class UserCreateSerializer(serializers.ModelSerializer):
+    """사용자 생성용 Serializer - 비밀번호 검증 포함"""
+    
+    password = serializers.CharField(write_only=True, validators=[validate_password])
+    password_confirm = serializers.CharField(write_only=True)
+    
+    class Meta:
+        model = User
+        fields = [
+            'username', 'email', 'first_name', 'last_name', 'password', 'password_confirm',
+            'role', 'employee_id', 'department', 'phone'
+        ]
+        
+    def validate(self, attrs):
+        if attrs['password'] != attrs['password_confirm']:
+            raise serializers.ValidationError("비밀번호가 일치하지 않습니다.")
+        return attrs
+    
+    def create(self, validated_data):
+        validated_data.pop('password_confirm')
+        password = validated_data.pop('password')
+        user = User.objects.create_user(password=password, **validated_data)
+        return user
+
+
+class UserUpdateSerializer(serializers.ModelSerializer):
+    """사용자 수정용 Serializer"""
+    
+    password = serializers.CharField(write_only=True, required=False, validators=[validate_password])
+    password_confirm = serializers.CharField(write_only=True, required=False)
+    
+    class Meta:
+        model = User
+        fields = [
+            'email', 'first_name', 'last_name', 'password', 'password_confirm',
+            'role', 'employee_id', 'department', 'phone', 'is_active'
+        ]
+        
+    def validate(self, attrs):
+        password = attrs.get('password')
+        password_confirm = attrs.get('password_confirm')
+        
+        if password or password_confirm:
+            if password != password_confirm:
+                raise serializers.ValidationError("비밀번호가 일치하지 않습니다.")
+        return attrs
+    
+    def update(self, instance, validated_data):
+        password = validated_data.pop('password', None)
+        validated_data.pop('password_confirm', None)
+        
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+            
+        if password:
+            instance.set_password(password)
+            
+        instance.save()
+        return instance

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,0 +1,29 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from core.views import (
+    UserViewSet,
+    SupplierViewSet, 
+    RawMaterialViewSet,
+    MaterialLotViewSet,
+    FinishedProductViewSet,
+    ProductionOrderViewSet,
+    CCPViewSet,
+    CCPLogViewSet,
+)
+
+# DRF Router로 ViewSet URL 자동 생성
+router = DefaultRouter()
+
+# ViewSet 등록
+router.register(r'users', UserViewSet, basename='user')
+router.register(r'suppliers', SupplierViewSet, basename='supplier')
+router.register(r'raw-materials', RawMaterialViewSet, basename='rawmaterial')
+router.register(r'material-lots', MaterialLotViewSet, basename='materiallot')
+router.register(r'finished-products', FinishedProductViewSet, basename='finishedproduct')
+router.register(r'production-orders', ProductionOrderViewSet, basename='productionorder')
+router.register(r'ccps', CCPViewSet, basename='ccp')
+router.register(r'ccp-logs', CCPLogViewSet, basename='ccplog')
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/backend/core/views/__init__.py
+++ b/backend/core/views/__init__.py
@@ -1,0 +1,17 @@
+from .user_views import UserViewSet
+from .supplier_views import SupplierViewSet
+from .raw_material_views import RawMaterialViewSet, MaterialLotViewSet
+from .product_views import FinishedProductViewSet
+from .production_views import ProductionOrderViewSet
+from .haccp_views import CCPViewSet, CCPLogViewSet
+
+__all__ = [
+    'UserViewSet',
+    'SupplierViewSet', 
+    'RawMaterialViewSet',
+    'MaterialLotViewSet',
+    'FinishedProductViewSet',
+    'ProductionOrderViewSet',
+    'CCPViewSet',
+    'CCPLogViewSet',
+]

--- a/backend/core/views/haccp_views.py
+++ b/backend/core/views/haccp_views.py
@@ -1,0 +1,341 @@
+from rest_framework import viewsets, status, filters
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django_filters.rest_framework import DjangoFilterBackend
+from django.db.models import Count, Avg, Q
+from django.utils import timezone
+from datetime import timedelta
+from core.models import CCP, CCPLog
+from core.serializers import (
+    CCPSerializer, CCPCreateSerializer,
+    CCPLogSerializer, CCPLogCreateSerializer, CCPLogUpdateSerializer
+)
+
+
+class CCPViewSet(viewsets.ModelViewSet):
+    """중요 관리점(CCP) 관리 ViewSet"""
+    
+    queryset = CCP.objects.all()
+    permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ['ccp_type', 'finished_product', 'is_active']
+    search_fields = ['name', 'code', 'description', 'process_step']
+    ordering_fields = ['name', 'code', 'created_at']
+    ordering = ['-created_at']
+    
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return CCPCreateSerializer
+        return CCPSerializer
+    
+    def get_queryset(self):
+        """역할별 CCP 조회 권한"""
+        user = self.request.user
+        
+        # 감사자는 모든 CCP 조회 가능
+        if user.role == 'auditor':
+            return CCP.objects.all()
+        
+        # 작업자는 활성 CCP만 조회
+        if user.role == 'operator':
+            return CCP.objects.filter(is_active=True)
+            
+        return CCP.objects.all()
+    
+    def perform_destroy(self, instance):
+        """CCP 삭제 시 로그 존재 확인"""
+        if instance.logs.exists():
+            from rest_framework.exceptions import ValidationError
+            raise ValidationError("모니터링 로그가 존재하는 CCP는 삭제할 수 없습니다. 비활성화하세요.")
+        
+        super().perform_destroy(instance)
+    
+    @action(detail=True, methods=['get'])
+    def monitoring_logs(self, request, pk=None):
+        """특정 CCP의 모니터링 로그"""
+        ccp = self.get_object()
+        
+        # 날짜 범위 필터
+        start_date = request.query_params.get('start_date')
+        end_date = request.query_params.get('end_date')
+        status_filter = request.query_params.get('status')
+        
+        queryset = ccp.logs.all()
+        
+        if start_date:
+            queryset = queryset.filter(measured_at__gte=start_date)
+        if end_date:
+            queryset = queryset.filter(measured_at__lte=end_date)
+        if status_filter:
+            queryset = queryset.filter(status=status_filter)
+        
+        # 최근 100개 제한
+        logs = queryset.order_by('-measured_at')[:100]
+        serializer = CCPLogSerializer(logs, many=True)
+        
+        return Response({
+            'ccp_info': {
+                'name': ccp.name,
+                'code': ccp.code,
+                'type': ccp.get_ccp_type_display(),
+                'process_step': ccp.process_step
+            },
+            'logs': serializer.data,
+            'total_logs': ccp.logs.count()
+        })
+    
+    @action(detail=True, methods=['get'])
+    def compliance_report(self, request, pk=None):
+        """CCP 규정 준수 보고서"""
+        ccp = self.get_object()
+        
+        # 분석 기간 (기본 30일)
+        days = int(request.query_params.get('days', '30'))
+        start_date = timezone.now() - timedelta(days=days)
+        
+        logs = ccp.logs.filter(measured_at__gte=start_date)
+        
+        if not logs.exists():
+            return Response({
+                'ccp_name': ccp.name,
+                'analysis_period': f'최근 {days}일',
+                'message': '해당 기간에 모니터링 로그가 없습니다.'
+            })
+        
+        total_logs = logs.count()
+        within_limits = logs.filter(status='within_limits').count()
+        out_of_limits = logs.filter(status='out_of_limits').count()
+        corrective_action = logs.filter(status='corrective_action').count()
+        
+        compliance_rate = (within_limits / total_logs * 100) if total_logs > 0 else 0
+        
+        # 일별 로그 수 분포
+        daily_logs = logs.extra({
+            'date': 'DATE(measured_at)'
+        }).values('date').annotate(
+            count=Count('id'),
+            out_of_limits_count=Count('id', filter=Q(status='out_of_limits'))
+        ).order_by('date')
+        
+        # 편차 분석
+        deviation_analysis = []
+        if ccp.critical_limit_min or ccp.critical_limit_max:
+            out_of_limit_logs = logs.filter(status='out_of_limits')
+            for log in out_of_limit_logs:
+                measured = float(log.measured_value)
+                deviation = 0
+                
+                if ccp.critical_limit_min and measured < float(ccp.critical_limit_min):
+                    deviation = measured - float(ccp.critical_limit_min)
+                elif ccp.critical_limit_max and measured > float(ccp.critical_limit_max):
+                    deviation = measured - float(ccp.critical_limit_max)
+                
+                deviation_analysis.append({
+                    'measured_at': log.measured_at,
+                    'measured_value': measured,
+                    'deviation': deviation,
+                    'corrective_action': log.corrective_action_taken
+                })
+        
+        return Response({
+            'ccp_info': {
+                'name': ccp.name,
+                'code': ccp.code,
+                'type': ccp.get_ccp_type_display(),
+                'critical_limits': {
+                    'min': ccp.critical_limit_min,
+                    'max': ccp.critical_limit_max
+                }
+            },
+            'analysis_period': f'최근 {days}일',
+            'compliance_summary': {
+                'total_measurements': total_logs,
+                'within_limits': within_limits,
+                'out_of_limits': out_of_limits,
+                'corrective_actions': corrective_action,
+                'compliance_rate': round(compliance_rate, 2)
+            },
+            'daily_monitoring': list(daily_logs),
+            'deviation_incidents': deviation_analysis[:10]  # 최근 10건만
+        })
+    
+    @action(detail=False, methods=['get'])
+    def types(self, request):
+        """CCP 타입 목록"""
+        types = [{'key': key, 'value': value} for key, value in CCP.CCP_TYPE_CHOICES]
+        return Response(types)
+    
+    @action(detail=False, methods=['get'])
+    def critical_alerts(self, request):
+        """중요 알림 - 최근 기준 이탈 CCP"""
+        hours = int(request.query_params.get('hours', '24'))
+        start_time = timezone.now() - timedelta(hours=hours)
+        
+        # 최근 기준 이탈 로그가 있는 CCP들
+        critical_ccps = CCP.objects.filter(
+            logs__measured_at__gte=start_time,
+            logs__status='out_of_limits',
+            is_active=True
+        ).distinct()
+        
+        alerts = []
+        for ccp in critical_ccps:
+            recent_violations = ccp.logs.filter(
+                measured_at__gte=start_time,
+                status='out_of_limits'
+            ).order_by('-measured_at')[:5]
+            
+            alerts.append({
+                'ccp_id': ccp.id,
+                'ccp_name': ccp.name,
+                'ccp_code': ccp.code,
+                'process_step': ccp.process_step,
+                'violation_count': recent_violations.count(),
+                'latest_violation': {
+                    'measured_at': recent_violations.first().measured_at,
+                    'measured_value': recent_violations.first().measured_value,
+                    'deviation_notes': recent_violations.first().deviation_notes
+                } if recent_violations.exists() else None
+            })
+        
+        return Response({
+            'alert_period': f'최근 {hours}시간',
+            'critical_ccps': alerts,
+            'total_alerts': len(alerts)
+        })
+
+
+class CCPLogViewSet(viewsets.ModelViewSet):
+    """CCP 모니터링 로그 ViewSet - 불변 데이터"""
+    
+    queryset = CCPLog.objects.all()
+    permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ['status', 'ccp', 'production_order', 'is_within_limits']
+    search_fields = ['ccp__name', 'deviation_notes', 'corrective_action_taken']
+    ordering_fields = ['measured_at', 'created_at']
+    ordering = ['-measured_at']
+    
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return CCPLogCreateSerializer
+        elif self.action in ['update', 'partial_update']:
+            return CCPLogUpdateSerializer  # 개선조치 정보만 수정 가능
+        return CCPLogSerializer
+    
+    def get_queryset(self):
+        """로그 조회 필터링"""
+        queryset = CCPLog.objects.select_related(
+            'ccp', 'production_order', 'created_by'
+        )
+        
+        # 날짜 범위 필터
+        start_date = self.request.query_params.get('start_date')
+        end_date = self.request.query_params.get('end_date')
+        
+        if start_date:
+            queryset = queryset.filter(measured_at__gte=start_date)
+        if end_date:
+            queryset = queryset.filter(measured_at__lte=end_date)
+        
+        # 작업자는 자신이 생성한 로그만 수정 가능
+        if self.action in ['update', 'partial_update'] and self.request.user.role == 'operator':
+            queryset = queryset.filter(created_by=self.request.user)
+            
+        return queryset
+    
+    def perform_destroy(self, instance):
+        """CCP 로그는 삭제 불가 (HACCP 규정 준수)"""
+        from rest_framework.exceptions import PermissionDenied
+        raise PermissionDenied("CCP 모니터링 로그는 삭제할 수 없습니다. (HACCP 규정 준수)")
+    
+    @action(detail=False, methods=['get'])
+    def recent_violations(self, request):
+        """최근 기준 이탈 로그"""
+        hours = int(request.query_params.get('hours', '24'))
+        start_time = timezone.now() - timedelta(hours=hours)
+        
+        violations = CCPLog.objects.filter(
+            measured_at__gte=start_time,
+            status='out_of_limits'
+        ).select_related('ccp', 'created_by').order_by('-measured_at')
+        
+        serializer = CCPLogSerializer(violations, many=True)
+        return Response({
+            'period': f'최근 {hours}시간',
+            'violations': serializer.data,
+            'total_count': violations.count()
+        })
+    
+    @action(detail=False, methods=['get'])
+    def pending_actions(self, request):
+        """개선조치 필요한 로그"""
+        pending_logs = CCPLog.objects.filter(
+            status='out_of_limits',
+            corrective_action_taken__isnull=True
+        ).select_related('ccp', 'created_by').order_by('-measured_at')[:50]
+        
+        serializer = CCPLogSerializer(pending_logs, many=True)
+        return Response({
+            'pending_logs': serializer.data,
+            'total_count': pending_logs.count()
+        })
+    
+    @action(detail=False, methods=['get'])
+    def verification_needed(self, request):
+        """검증 필요한 로그"""
+        verification_needed = CCPLog.objects.filter(
+            status='corrective_action',
+            verified_by__isnull=True
+        ).select_related('ccp', 'corrective_action_by').order_by('-measured_at')[:50]
+        
+        serializer = CCPLogSerializer(verification_needed, many=True)
+        return Response({
+            'verification_needed': serializer.data,
+            'total_count': verification_needed.count()
+        })
+    
+    @action(detail=False, methods=['get'])
+    def statistics(self, request):
+        """CCP 로그 통계"""
+        # 최근 30일 통계
+        thirty_days_ago = timezone.now() - timedelta(days=30)
+        recent_logs = CCPLog.objects.filter(measured_at__gte=thirty_days_ago)
+        
+        total_logs = recent_logs.count()
+        within_limits = recent_logs.filter(status='within_limits').count()
+        out_of_limits = recent_logs.filter(status='out_of_limits').count()
+        corrective_actions = recent_logs.filter(status='corrective_action').count()
+        
+        # CCP 타입별 위반 현황
+        violation_by_type = recent_logs.filter(
+            status='out_of_limits'
+        ).values(
+            'ccp__ccp_type'
+        ).annotate(
+            count=Count('id')
+        ).order_by('-count')
+        
+        # 가장 많이 위반되는 CCP
+        frequent_violations = recent_logs.filter(
+            status='out_of_limits'
+        ).values(
+            'ccp__name',
+            'ccp__code'
+        ).annotate(
+            violation_count=Count('id')
+        ).order_by('-violation_count')[:10]
+        
+        return Response({
+            'analysis_period': '최근 30일',
+            'overall_statistics': {
+                'total_measurements': total_logs,
+                'within_limits': within_limits,
+                'out_of_limits': out_of_limits,
+                'corrective_actions': corrective_actions,
+                'compliance_rate': round((within_limits / total_logs * 100), 2) if total_logs > 0 else 0
+            },
+            'violations_by_type': list(violation_by_type),
+            'frequent_violation_ccps': list(frequent_violations)
+        })

--- a/backend/core/views/product_views.py
+++ b/backend/core/views/product_views.py
@@ -1,0 +1,229 @@
+from rest_framework import viewsets, status, filters
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django_filters.rest_framework import DjangoFilterBackend
+from django.db.models import Count, Q
+from core.models import FinishedProduct, ProductionOrder
+from core.serializers import FinishedProductSerializer, FinishedProductCreateSerializer, FinishedProductUpdateSerializer
+
+
+class FinishedProductViewSet(viewsets.ModelViewSet):
+    """완제품 관리 ViewSet"""
+    
+    queryset = FinishedProduct.objects.all()
+    permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ['is_active']
+    search_fields = ['name', 'code', 'description']
+    ordering_fields = ['name', 'code', 'created_at']
+    ordering = ['-created_at']
+    
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return FinishedProductCreateSerializer
+        elif self.action in ['update', 'partial_update']:
+            return FinishedProductUpdateSerializer
+        return FinishedProductSerializer
+    
+    def get_queryset(self):
+        """역할별 제품 조회 권한"""
+        user = self.request.user
+        
+        # 작업자는 활성 제품만 조회 가능
+        if user.role == 'operator':
+            return FinishedProduct.objects.filter(is_active=True)
+            
+        return FinishedProduct.objects.all()
+    
+    def perform_destroy(self, instance):
+        """제품 삭제 시 생산오더 확인"""
+        if instance.production_orders.exists():
+            from rest_framework.exceptions import ValidationError
+            raise ValidationError("생산오더가 존재하는 제품은 삭제할 수 없습니다.")
+        
+        super().perform_destroy(instance)
+    
+    @action(detail=True, methods=['get'])
+    def production_history(self, request, pk=None):
+        """제품 생산 이력"""
+        product = self.get_object()
+        
+        # 최근 생산오더 조회
+        limit = int(request.query_params.get('limit', '20'))
+        orders = product.production_orders.order_by('-created_at')[:limit]
+        
+        production_data = []
+        for order in orders:
+            production_data.append({
+                'id': order.id,
+                'order_number': order.order_number,
+                'planned_quantity': order.planned_quantity,
+                'produced_quantity': order.produced_quantity,
+                'status': order.status,
+                'planned_start_date': order.planned_start_date,
+                'planned_end_date': order.planned_end_date,
+                'actual_start_date': order.actual_start_date,
+                'actual_end_date': order.actual_end_date,
+                'completion_rate': (order.produced_quantity / order.planned_quantity * 100) if order.planned_quantity > 0 else 0
+            })
+        
+        return Response({
+            'product_name': product.name,
+            'product_code': product.code,
+            'production_history': production_data,
+            'total_orders': product.production_orders.count()
+        })
+    
+    @action(detail=True, methods=['get'])
+    def production_statistics(self, request, pk=None):
+        """제품 생산 통계"""
+        product = self.get_object()
+        
+        # 전체 생산 통계
+        all_orders = product.production_orders.all()
+        total_orders = all_orders.count()
+        completed_orders = all_orders.filter(status='completed').count()
+        
+        # 총 생산량
+        total_produced = sum([order.produced_quantity for order in all_orders])
+        total_planned = sum([order.planned_quantity for order in all_orders])
+        
+        # 평균 완료율
+        avg_completion = (completed_orders / total_orders * 100) if total_orders > 0 else 0
+        
+        # 상태별 분포
+        status_distribution = {}
+        for choice in ProductionOrder.STATUS_CHOICES:
+            status_key = choice[0]
+            status_name = choice[1]
+            count = all_orders.filter(status=status_key).count()
+            status_distribution[status_name] = count
+        
+        # 최근 30일 생산 성과
+        from datetime import datetime, timedelta
+        thirty_days_ago = datetime.now() - timedelta(days=30)
+        recent_orders = all_orders.filter(created_at__gte=thirty_days_ago)
+        
+        recent_produced = sum([order.produced_quantity for order in recent_orders])
+        recent_completed = recent_orders.filter(status='completed').count()
+        
+        return Response({
+            'product_info': {
+                'name': product.name,
+                'code': product.code,
+                'version': product.version
+            },
+            'overall_statistics': {
+                'total_orders': total_orders,
+                'completed_orders': completed_orders,
+                'completion_rate': round(avg_completion, 2),
+                'total_produced': total_produced,
+                'total_planned': total_planned,
+                'production_efficiency': round((total_produced / total_planned * 100), 2) if total_planned > 0 else 0
+            },
+            'status_distribution': status_distribution,
+            'recent_30_days': {
+                'orders_count': recent_orders.count(),
+                'completed_orders': recent_completed,
+                'total_produced': recent_produced
+            }
+        })
+    
+    @action(detail=True, methods=['get'])
+    def ccps(self, request, pk=None):
+        """제품별 중요 관리점(CCP) 목록"""
+        product = self.get_object()
+        
+        ccps = product.ccps.filter(is_active=True)
+        
+        ccp_data = []
+        for ccp in ccps:
+            # 최근 로그 통계
+            recent_logs = ccp.logs.filter(
+                measured_at__gte=datetime.now() - timedelta(days=30)
+            )
+            
+            ccp_data.append({
+                'id': ccp.id,
+                'name': ccp.name,
+                'code': ccp.code,
+                'ccp_type': ccp.get_ccp_type_display(),
+                'process_step': ccp.process_step,
+                'critical_limits': {
+                    'min': ccp.critical_limit_min,
+                    'max': ccp.critical_limit_max
+                },
+                'monitoring_frequency': ccp.monitoring_frequency,
+                'recent_performance': {
+                    'total_logs': recent_logs.count(),
+                    'out_of_limits': recent_logs.filter(status='out_of_limits').count(),
+                    'compliance_rate': round(
+                        (recent_logs.filter(status='within_limits').count() / recent_logs.count() * 100), 2
+                    ) if recent_logs.count() > 0 else 0
+                }
+            })
+        
+        return Response({
+            'product_name': product.name,
+            'ccps': ccp_data,
+            'total_ccps': len(ccp_data)
+        })
+    
+    @action(detail=False, methods=['get'])
+    def active_products(self, request):
+        """활성 제품 목록 (간단 버전)"""
+        products = FinishedProduct.objects.filter(is_active=True).only(
+            'id', 'name', 'code', 'version', 'net_weight', 'packaging_type'
+        )
+        
+        simple_products = []
+        for product in products:
+            simple_products.append({
+                'id': product.id,
+                'name': product.name,
+                'code': product.code,
+                'version': product.version,
+                'net_weight': product.net_weight,
+                'packaging_type': product.packaging_type
+            })
+        
+        return Response(simple_products)
+    
+    @action(detail=False, methods=['get'])
+    def product_catalog(self, request):
+        """제품 카탈로그 (상세 정보 포함)"""
+        products = FinishedProduct.objects.filter(is_active=True)
+        
+        catalog = []
+        for product in products:
+            # 최근 생산 정보
+            latest_order = product.production_orders.order_by('-created_at').first()
+            
+            catalog.append({
+                'id': product.id,
+                'name': product.name,
+                'code': product.code,
+                'version': product.version,
+                'description': product.description,
+                'specifications': {
+                    'net_weight': product.net_weight,
+                    'packaging_type': product.packaging_type,
+                    'shelf_life_days': product.shelf_life_days,
+                    'storage_temp': {
+                        'min': product.storage_temp_min,
+                        'max': product.storage_temp_max
+                    }
+                },
+                'allergen_info': product.allergen_info,
+                'nutrition_facts': product.nutrition_facts,
+                'latest_production': {
+                    'order_number': latest_order.order_number if latest_order else None,
+                    'date': latest_order.created_at if latest_order else None,
+                    'quantity': latest_order.produced_quantity if latest_order else 0
+                } if latest_order else None,
+                'total_production_orders': product.production_orders.count(),
+                'ccp_count': product.ccps.filter(is_active=True).count()
+            })
+        
+        return Response(catalog)

--- a/backend/core/views/production_views.py
+++ b/backend/core/views/production_views.py
@@ -1,0 +1,313 @@
+from rest_framework import viewsets, status, filters
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django_filters.rest_framework import DjangoFilterBackend
+from django.db.models import Sum, Count, Avg, Q, F
+from django.utils import timezone
+from datetime import timedelta
+from core.models import ProductionOrder
+from core.serializers import ProductionOrderSerializer, ProductionOrderCreateSerializer, ProductionOrderUpdateSerializer
+
+
+class ProductionOrderViewSet(viewsets.ModelViewSet):
+    """생산오더 관리 ViewSet"""
+    
+    queryset = ProductionOrder.objects.all()
+    permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ['status', 'priority', 'finished_product', 'assigned_operator']
+    search_fields = ['order_number', 'finished_product__name', 'notes']
+    ordering_fields = ['planned_start_date', 'priority', 'created_at']
+    ordering = ['-created_at']
+    
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return ProductionOrderCreateSerializer
+        elif self.action in ['update', 'partial_update']:
+            return ProductionOrderUpdateSerializer
+        return ProductionOrderSerializer
+    
+    def get_queryset(self):
+        """역할별 생산오더 조회 권한"""
+        user = self.request.user
+        queryset = ProductionOrder.objects.select_related(
+            'finished_product', 'assigned_operator', 'created_by'
+        )
+        
+        # 작업자는 자신에게 할당된 오더만 조회
+        if user.role == 'operator':
+            queryset = queryset.filter(
+                Q(assigned_operator=user) | Q(assigned_operator__isnull=True)
+            )
+        
+        # 날짜 범위 필터
+        start_date = self.request.query_params.get('start_date')
+        end_date = self.request.query_params.get('end_date')
+        
+        if start_date:
+            queryset = queryset.filter(planned_start_date__gte=start_date)
+        if end_date:
+            queryset = queryset.filter(planned_end_date__lte=end_date)
+            
+        return queryset
+    
+    @action(detail=True, methods=['post'])
+    def start_production(self, request, pk=None):
+        """생산 시작"""
+        order = self.get_object()
+        
+        if order.status != 'planned':
+            return Response(
+                {'detail': '계획 상태의 오더만 시작할 수 있습니다.'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        order.status = 'in_progress'
+        order.actual_start_date = timezone.now()
+        
+        # 작업자가 지정되지 않은 경우 현재 사용자로 설정
+        if not order.assigned_operator:
+            order.assigned_operator = request.user
+            
+        order.save()
+        
+        serializer = ProductionOrderSerializer(order)
+        return Response({
+            'detail': '생산이 시작되었습니다.',
+            'order': serializer.data
+        })
+    
+    @action(detail=True, methods=['post'])
+    def complete_production(self, request, pk=None):
+        """생산 완료"""
+        order = self.get_object()
+        
+        if order.status != 'in_progress':
+            return Response(
+                {'detail': '진행 중인 오더만 완료할 수 있습니다.'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        produced_quantity = request.data.get('produced_quantity')
+        completion_notes = request.data.get('notes', '')
+        
+        if produced_quantity is not None:
+            order.produced_quantity = produced_quantity
+        
+        order.status = 'completed'
+        order.actual_end_date = timezone.now()
+        
+        if completion_notes:
+            order.notes = f"{order.notes}\n완료 시 메모: {completion_notes}".strip()
+        
+        order.save()
+        
+        serializer = ProductionOrderSerializer(order)
+        return Response({
+            'detail': '생산이 완료되었습니다.',
+            'order': serializer.data
+        })
+    
+    @action(detail=True, methods=['post'])
+    def pause_production(self, request, pk=None):
+        """생산 일시정지"""
+        order = self.get_object()
+        
+        if order.status != 'in_progress':
+            return Response(
+                {'detail': '진행 중인 오더만 일시정지할 수 있습니다.'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        pause_reason = request.data.get('reason', '')
+        
+        order.status = 'on_hold'
+        if pause_reason:
+            order.notes = f"{order.notes}\n일시정지: {pause_reason}".strip()
+        
+        order.save()
+        
+        return Response({
+            'detail': '생산이 일시정지되었습니다.',
+            'order': ProductionOrderSerializer(order).data
+        })
+    
+    @action(detail=True, methods=['post'])
+    def resume_production(self, request, pk=None):
+        """생산 재개"""
+        order = self.get_object()
+        
+        if order.status != 'on_hold':
+            return Response(
+                {'detail': '일시정지 상태의 오더만 재개할 수 있습니다.'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        order.status = 'in_progress'
+        order.notes = f"{order.notes}\n생산 재개".strip()
+        order.save()
+        
+        return Response({
+            'detail': '생산이 재개되었습니다.',
+            'order': ProductionOrderSerializer(order).data
+        })
+    
+    @action(detail=True, methods=['get'])
+    def ccp_logs(self, request, pk=None):
+        """생산오더와 연결된 CCP 로그"""
+        order = self.get_object()
+        
+        ccp_logs = order.ccp_logs.select_related('ccp', 'created_by').order_by('-measured_at')[:50]
+        
+        logs_data = []
+        for log in ccp_logs:
+            logs_data.append({
+                'id': log.id,
+                'ccp_name': log.ccp.name,
+                'ccp_type': log.ccp.get_ccp_type_display(),
+                'measured_value': log.measured_value,
+                'unit': log.unit,
+                'measured_at': log.measured_at,
+                'status': log.get_status_display(),
+                'is_within_limits': log.is_within_limits,
+                'deviation_notes': log.deviation_notes,
+                'created_by': log.created_by.username
+            })
+        
+        return Response({
+            'order_number': order.order_number,
+            'product_name': order.finished_product.name,
+            'ccp_logs': logs_data,
+            'total_logs': order.ccp_logs.count()
+        })
+    
+    @action(detail=False, methods=['get'])
+    def dashboard(self, request):
+        """생산 대시보드 데이터"""
+        # 오늘 생산 현황
+        today = timezone.now().date()
+        today_orders = ProductionOrder.objects.filter(
+            planned_start_date__date=today
+        )
+        
+        # 전체 현황
+        all_orders = ProductionOrder.objects.all()
+        
+        # 상태별 분포
+        status_counts = {}
+        for status_key, status_name in ProductionOrder.STATUS_CHOICES:
+            count = all_orders.filter(status=status_key).count()
+            status_counts[status_name] = count
+        
+        # 우선순위별 분포
+        priority_counts = {}
+        for priority_key, priority_name in ProductionOrder.PRIORITY_CHOICES:
+            count = all_orders.filter(priority=priority_key).count()
+            priority_counts[priority_name] = count
+        
+        # 지연된 오더 (계획 종료일이 지났지만 완료되지 않은 것)
+        overdue_orders = all_orders.filter(
+            planned_end_date__lt=timezone.now(),
+            status__in=['planned', 'in_progress', 'on_hold']
+        ).count()
+        
+        # 최근 7일 완료 오더
+        week_ago = timezone.now() - timedelta(days=7)
+        recent_completed = all_orders.filter(
+            status='completed',
+            actual_end_date__gte=week_ago
+        ).count()
+        
+        # 평균 완료율
+        completed_orders = all_orders.filter(status='completed')
+        if completed_orders.exists():
+            avg_completion_rate = completed_orders.aggregate(
+                avg_rate=Avg('produced_quantity') * 100 / Avg('planned_quantity')
+            )['avg_rate'] or 0
+        else:
+            avg_completion_rate = 0
+        
+        return Response({
+            'today_summary': {
+                'total_orders': today_orders.count(),
+                'in_progress': today_orders.filter(status='in_progress').count(),
+                'completed': today_orders.filter(status='completed').count(),
+                'planned': today_orders.filter(status='planned').count()
+            },
+            'overall_summary': {
+                'total_orders': all_orders.count(),
+                'overdue_orders': overdue_orders,
+                'recent_completed': recent_completed,
+                'avg_completion_rate': round(avg_completion_rate, 2)
+            },
+            'status_distribution': status_counts,
+            'priority_distribution': priority_counts
+        })
+    
+    @action(detail=False, methods=['get'])
+    def upcoming(self, request):
+        """예정된 생산오더"""
+        days_ahead = int(request.query_params.get('days', '7'))
+        end_date = timezone.now() + timedelta(days=days_ahead)
+        
+        upcoming_orders = ProductionOrder.objects.filter(
+            planned_start_date__gte=timezone.now(),
+            planned_start_date__lte=end_date,
+            status='planned'
+        ).select_related('finished_product', 'assigned_operator').order_by('planned_start_date')
+        
+        serializer = ProductionOrderSerializer(upcoming_orders, many=True)
+        return Response({
+            'period_days': days_ahead,
+            'upcoming_orders': serializer.data,
+            'total_count': upcoming_orders.count()
+        })
+    
+    @action(detail=False, methods=['get'])
+    def performance(self, request):
+        """생산 성과 분석"""
+        # 최근 30일 성과
+        thirty_days_ago = timezone.now() - timedelta(days=30)
+        recent_orders = ProductionOrder.objects.filter(
+            actual_end_date__gte=thirty_days_ago,
+            status='completed'
+        )
+        
+        if not recent_orders.exists():
+            return Response({
+                'message': '최근 30일간 완료된 생산오더가 없습니다.'
+            })
+        
+        # 생산량 통계
+        total_planned = recent_orders.aggregate(Sum('planned_quantity'))['planned_quantity__sum'] or 0
+        total_produced = recent_orders.aggregate(Sum('produced_quantity'))['produced_quantity__sum'] or 0
+        
+        # 일정 준수율
+        on_time_orders = recent_orders.filter(
+            actual_end_date__lte=F('planned_end_date')
+        ).count()
+        
+        schedule_adherence = (on_time_orders / recent_orders.count() * 100) if recent_orders.count() > 0 else 0
+        
+        # 제품별 성과
+        product_performance = recent_orders.values(
+            'finished_product__name',
+            'finished_product__code'
+        ).annotate(
+            total_orders=Count('id'),
+            total_produced=Sum('produced_quantity'),
+            avg_completion_rate=Avg('produced_quantity') * 100 / Avg('planned_quantity')
+        ).order_by('-total_produced')[:10]
+        
+        return Response({
+            'analysis_period': '최근 30일',
+            'production_summary': {
+                'total_orders': recent_orders.count(),
+                'total_planned': total_planned,
+                'total_produced': total_produced,
+                'production_efficiency': round((total_produced / total_planned * 100), 2) if total_planned > 0 else 0,
+                'schedule_adherence': round(schedule_adherence, 2)
+            },
+            'top_products': list(product_performance)
+        })

--- a/backend/core/views/raw_material_views.py
+++ b/backend/core/views/raw_material_views.py
@@ -1,0 +1,287 @@
+from rest_framework import viewsets, status, filters
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django_filters.rest_framework import DjangoFilterBackend
+from django.db.models import Sum, Count, Q
+from datetime import datetime, timedelta, date
+from core.models import RawMaterial, MaterialLot
+from core.serializers import RawMaterialSerializer, MaterialLotSerializer, MaterialLotCreateSerializer
+
+
+class RawMaterialViewSet(viewsets.ModelViewSet):
+    """원자재 카탈로그 관리 ViewSet"""
+    
+    queryset = RawMaterial.objects.all()
+    permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ['category', 'supplier', 'is_active']
+    search_fields = ['name', 'code', 'description']
+    ordering_fields = ['name', 'code', 'created_at']
+    ordering = ['-created_at']
+    
+    def get_serializer_class(self):
+        return RawMaterialSerializer
+    
+    def get_queryset(self):
+        """역할별 원자재 조회 권한"""
+        user = self.request.user
+        
+        # 작업자는 활성 원자재만 조회 가능
+        if user.role == 'operator':
+            return RawMaterial.objects.filter(is_active=True)
+            
+        return RawMaterial.objects.all()
+    
+    @action(detail=True, methods=['get'])
+    def lots(self, request, pk=None):
+        """특정 원자재의 로트 목록"""
+        material = self.get_object()
+        
+        # 상태별 필터링
+        status_filter = request.query_params.get('status')
+        queryset = material.lots.all()
+        
+        if status_filter:
+            queryset = queryset.filter(status=status_filter)
+        
+        # 최신순 정렬, 최근 100개만
+        lots = queryset.order_by('-received_date')[:100]
+        
+        serializer = MaterialLotSerializer(lots, many=True)
+        return Response(serializer.data)
+    
+    @action(detail=True, methods=['get'])
+    def inventory(self, request, pk=None):
+        """특정 원자재의 재고 현황"""
+        material = self.get_object()
+        
+        # 현재 보유 로트들
+        current_lots = material.lots.filter(
+            status__in=['received', 'in_storage', 'in_use'],
+            quantity_current__gt=0
+        )
+        
+        total_quantity = current_lots.aggregate(
+            total=Sum('quantity_current')
+        )['total'] or 0
+        
+        # 유통기한별 분류
+        today = date.today()
+        near_expiry = current_lots.filter(
+            expiry_date__lte=today + timedelta(days=30)
+        ).count()
+        
+        expired = current_lots.filter(
+            expiry_date__lt=today
+        ).count()
+        
+        return Response({
+            'material_name': material.name,
+            'material_code': material.code,
+            'total_quantity': total_quantity,
+            'unit': material.unit,
+            'active_lots': current_lots.count(),
+            'near_expiry_lots': near_expiry,
+            'expired_lots': expired,
+            'storage_requirements': {
+                'temp_min': material.storage_temp_min,
+                'temp_max': material.storage_temp_max,
+                'shelf_life_days': material.shelf_life_days
+            }
+        })
+    
+    @action(detail=False, methods=['get'])
+    def categories(self, request):
+        """원자재 카테고리 목록"""
+        categories = [
+            {'key': key, 'value': value} 
+            for key, value in RawMaterial.CATEGORY_CHOICES
+        ]
+        return Response(categories)
+    
+    @action(detail=False, methods=['get'])
+    def low_stock(self, request):
+        """재고 부족 원자재 목록"""
+        # 임계값은 쿼리 파라미터로 받거나 기본값 사용
+        threshold = float(request.query_params.get('threshold', '10.0'))
+        
+        low_stock_materials = []
+        
+        for material in RawMaterial.objects.filter(is_active=True):
+            current_stock = material.lots.filter(
+                status__in=['received', 'in_storage'],
+                quantity_current__gt=0
+            ).aggregate(
+                total=Sum('quantity_current')
+            )['total'] or 0
+            
+            if current_stock <= threshold:
+                low_stock_materials.append({
+                    'id': material.id,
+                    'name': material.name,
+                    'code': material.code,
+                    'current_stock': current_stock,
+                    'unit': material.unit,
+                    'supplier': material.supplier.name,
+                    'category': material.get_category_display()
+                })
+        
+        return Response(low_stock_materials)
+
+
+class MaterialLotViewSet(viewsets.ModelViewSet):
+    """원자재 로트 관리 ViewSet - 추적성 핵심"""
+    
+    queryset = MaterialLot.objects.all()
+    permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ['status', 'raw_material', 'supplier', 'quality_test_passed']
+    search_fields = ['lot_number', 'raw_material__name', 'supplier__name']
+    ordering_fields = ['received_date', 'expiry_date', 'created_at']
+    ordering = ['-received_date']
+    
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return MaterialLotCreateSerializer
+        return MaterialLotSerializer
+    
+    def get_queryset(self):
+        """로트 조회 필터링"""
+        queryset = MaterialLot.objects.select_related(
+            'raw_material', 'supplier', 'created_by'
+        )
+        
+        # 날짜 범위 필터
+        start_date = self.request.query_params.get('start_date')
+        end_date = self.request.query_params.get('end_date')
+        
+        if start_date:
+            queryset = queryset.filter(received_date__gte=start_date)
+        if end_date:
+            queryset = queryset.filter(received_date__lte=end_date)
+        
+        return queryset
+    
+    @action(detail=True, methods=['post'])
+    def consume(self, request, pk=None):
+        """로트 소비/사용"""
+        lot = self.get_object()
+        consume_quantity = float(request.data.get('quantity', 0))
+        
+        if consume_quantity <= 0:
+            return Response(
+                {'detail': '소비 수량은 0보다 커야 합니다.'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        if consume_quantity > lot.quantity_current:
+            return Response(
+                {'detail': '소비 수량이 현재 수량을 초과합니다.'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        # 수량 차감
+        lot.quantity_current -= consume_quantity
+        
+        # 상태 업데이트
+        if lot.quantity_current == 0:
+            lot.status = 'used'
+        else:
+            lot.status = 'in_use'
+        
+        lot.save()
+        
+        # 사용 기록 로깅 (향후 별도 모델로 확장 가능)
+        return Response({
+            'detail': f'{consume_quantity}{lot.raw_material.unit} 소비 처리되었습니다.',
+            'remaining_quantity': lot.quantity_current,
+            'new_status': lot.status
+        })
+    
+    @action(detail=True, methods=['get'])
+    def traceability(self, request, pk=None):
+        """로트 추적성 정보"""
+        lot = self.get_object()
+        
+        # 기본 추적 정보
+        trace_data = {
+            'lot_info': {
+                'lot_number': lot.lot_number,
+                'raw_material': lot.raw_material.name,
+                'supplier': lot.supplier.name,
+                'received_date': lot.received_date,
+                'expiry_date': lot.expiry_date
+            },
+            'quality_control': {
+                'test_passed': lot.quality_test_passed,
+                'test_date': lot.quality_test_date,
+                'test_notes': lot.quality_test_notes,
+                'temperature_at_receipt': lot.temperature_at_receipt
+            },
+            'usage_history': {
+                'original_quantity': lot.quantity_received,
+                'current_quantity': lot.quantity_current,
+                'consumed_quantity': lot.quantity_received - lot.quantity_current,
+                'usage_rate': ((lot.quantity_received - lot.quantity_current) / lot.quantity_received * 100) if lot.quantity_received > 0 else 0
+            }
+        }
+        
+        # 향후 생산오더 연결 정보도 추가 가능
+        # trace_data['production_usage'] = ProductionOrder.objects.filter(...)
+        
+        return Response(trace_data)
+    
+    @action(detail=False, methods=['get'])
+    def expiring_soon(self, request):
+        """유통기한 임박 로트"""
+        days_ahead = int(request.query_params.get('days', '7'))
+        threshold_date = date.today() + timedelta(days=days_ahead)
+        
+        expiring_lots = MaterialLot.objects.filter(
+            expiry_date__lte=threshold_date,
+            expiry_date__gte=date.today(),
+            status__in=['received', 'in_storage', 'in_use'],
+            quantity_current__gt=0
+        ).select_related('raw_material', 'supplier')
+        
+        serializer = MaterialLotSerializer(expiring_lots, many=True)
+        return Response({
+            'threshold_days': days_ahead,
+            'expiring_lots': serializer.data,
+            'total_count': expiring_lots.count()
+        })
+    
+    @action(detail=False, methods=['get'])
+    def quality_summary(self, request):
+        """품질검사 요약"""
+        # 최근 30일 품질검사 현황
+        thirty_days_ago = datetime.now() - timedelta(days=30)
+        
+        recent_lots = MaterialLot.objects.filter(
+            received_date__gte=thirty_days_ago
+        )
+        
+        total_lots = recent_lots.count()
+        passed_lots = recent_lots.filter(quality_test_passed=True).count()
+        failed_lots = recent_lots.filter(quality_test_passed=False).count()
+        pending_lots = recent_lots.filter(quality_test_passed__isnull=True).count()
+        
+        pass_rate = (passed_lots / total_lots * 100) if total_lots > 0 else 0
+        
+        return Response({
+            'period': '최근 30일',
+            'total_lots': total_lots,
+            'quality_results': {
+                'passed': passed_lots,
+                'failed': failed_lots,
+                'pending': pending_lots,
+                'pass_rate': round(pass_rate, 2)
+            },
+            'failed_suppliers': list(
+                recent_lots.filter(quality_test_passed=False)
+                .values('supplier__name')
+                .annotate(count=Count('id'))
+                .order_by('-count')[:5]
+            )
+        })

--- a/backend/core/views/supplier_views.py
+++ b/backend/core/views/supplier_views.py
@@ -1,0 +1,168 @@
+from rest_framework import viewsets, status, filters
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django_filters.rest_framework import DjangoFilterBackend
+from django.db.models import Count, Q
+from core.models import Supplier, MaterialLot
+from core.serializers import SupplierSerializer, SupplierCreateSerializer, SupplierUpdateSerializer
+
+
+class SupplierViewSet(viewsets.ModelViewSet):
+    """공급업체 관리 ViewSet"""
+    
+    queryset = Supplier.objects.all()
+    permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ['status']
+    search_fields = ['name', 'code', 'contact_person', 'email']
+    ordering_fields = ['name', 'code', 'created_at']
+    ordering = ['-created_at']
+    
+    def get_serializer_class(self):
+        """액션에 따라 다른 Serializer 사용"""
+        if self.action == 'create':
+            return SupplierCreateSerializer
+        elif self.action in ['update', 'partial_update']:
+            return SupplierUpdateSerializer
+        return SupplierSerializer
+    
+    def get_queryset(self):
+        """역할별 공급업체 조회 권한"""
+        user = self.request.user
+        
+        # 작업자는 활성 공급업체만 조회 가능
+        if user.role == 'operator':
+            return Supplier.objects.filter(status='active')
+            
+        return Supplier.objects.all()
+    
+    def perform_create(self, serializer):
+        """공급업체 생성 시 생성자 자동 설정"""
+        serializer.save(created_by=self.request.user)
+    
+    def perform_destroy(self, instance):
+        """공급업체 삭제 시 연관 데이터 확인"""
+        # 원자재 로트가 있는 경우 삭제 불가
+        if instance.material_lots.exists():
+            from rest_framework.exceptions import ValidationError
+            raise ValidationError("원자재 로트가 존재하는 공급업체는 삭제할 수 없습니다.")
+        
+        super().perform_destroy(instance)
+    
+    @action(detail=True, methods=['get'])
+    def materials(self, request, pk=None):
+        """특정 공급업체의 원자재 목록"""
+        supplier = self.get_object()
+        materials = supplier.raw_materials.filter(is_active=True)
+        
+        # 간단한 원자재 정보만 반환
+        material_data = []
+        for material in materials:
+            material_data.append({
+                'id': material.id,
+                'name': material.name,
+                'code': material.code,
+                'category': material.category,
+                'unit': material.unit,
+                'is_active': material.is_active
+            })
+        
+        return Response(material_data)
+    
+    @action(detail=True, methods=['get'])
+    def material_lots(self, request, pk=None):
+        """특정 공급업체의 원자재 로트 목록"""
+        supplier = self.get_object()
+        
+        # 쿼리 파라미터로 상태 필터링
+        status_filter = request.query_params.get('status')
+        lots = supplier.material_lots.all()
+        
+        if status_filter:
+            lots = lots.filter(status=status_filter)
+        
+        # 최근 50개만 반환
+        lots = lots.order_by('-created_at')[:50]
+        
+        lot_data = []
+        for lot in lots:
+            lot_data.append({
+                'id': lot.id,
+                'lot_number': lot.lot_number,
+                'raw_material_name': lot.raw_material.name,
+                'received_date': lot.received_date,
+                'expiry_date': lot.expiry_date,
+                'quantity_current': lot.quantity_current,
+                'status': lot.status,
+                'quality_test_passed': lot.quality_test_passed
+            })
+        
+        return Response(lot_data)
+    
+    @action(detail=True, methods=['get'])
+    def performance(self, request, pk=None):
+        """공급업체 성과 분석"""
+        supplier = self.get_object()
+        
+        # 최근 6개월간 로트 분석
+        from datetime import datetime, timedelta
+        six_months_ago = datetime.now() - timedelta(days=180)
+        
+        lots = MaterialLot.objects.filter(
+            supplier=supplier,
+            received_date__gte=six_months_ago
+        )
+        
+        total_lots = lots.count()
+        quality_passed = lots.filter(quality_test_passed=True).count()
+        quality_failed = lots.filter(quality_test_passed=False).count()
+        quality_pending = lots.filter(quality_test_passed__isnull=True).count()
+        
+        # 평균 납기일 준수율 계산 (실제로는 더 복잡한 로직 필요)
+        on_time_delivery = lots.filter(status='received').count()
+        delivery_rate = (on_time_delivery / total_lots * 100) if total_lots > 0 else 0
+        
+        # 품질 합격률
+        tested_lots = quality_passed + quality_failed
+        quality_rate = (quality_passed / tested_lots * 100) if tested_lots > 0 else 0
+        
+        return Response({
+            'supplier_name': supplier.name,
+            'analysis_period': '최근 6개월',
+            'total_lots': total_lots,
+            'quality_summary': {
+                'passed': quality_passed,
+                'failed': quality_failed,
+                'pending': quality_pending,
+                'pass_rate': round(quality_rate, 2)
+            },
+            'delivery_performance': {
+                'on_time_deliveries': on_time_delivery,
+                'delivery_rate': round(delivery_rate, 2)
+            }
+        })
+    
+    @action(detail=False, methods=['get'])
+    def statistics(self, request):
+        """공급업체 전체 통계"""
+        total_suppliers = Supplier.objects.count()
+        active_suppliers = Supplier.objects.filter(status='active').count()
+        inactive_suppliers = Supplier.objects.filter(status='inactive').count()
+        suspended_suppliers = Supplier.objects.filter(status='suspended').count()
+        
+        # 공급업체별 원자재 수
+        suppliers_with_materials = Supplier.objects.annotate(
+            material_count=Count('raw_materials')
+        ).filter(material_count__gt=0).count()
+        
+        return Response({
+            'total_suppliers': total_suppliers,
+            'status_breakdown': {
+                'active': active_suppliers,
+                'inactive': inactive_suppliers,
+                'suspended': suspended_suppliers
+            },
+            'suppliers_with_materials': suppliers_with_materials,
+            'suppliers_without_materials': total_suppliers - suppliers_with_materials
+        })

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -1,0 +1,121 @@
+from rest_framework import viewsets, status, filters
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django_filters.rest_framework import DjangoFilterBackend
+from django.contrib.auth import get_user_model
+from core.models import User
+from core.serializers import UserSerializer, UserCreateSerializer, UserUpdateSerializer
+
+User = get_user_model()
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    """사용자 관리 ViewSet"""
+    
+    queryset = User.objects.all()
+    permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ['role', 'is_active', 'department']
+    search_fields = ['username', 'first_name', 'last_name', 'email', 'employee_id']
+    ordering_fields = ['username', 'created_at', 'last_login']
+    ordering = ['-created_at']
+    
+    def get_serializer_class(self):
+        """액션에 따라 다른 Serializer 사용"""
+        if self.action == 'create':
+            return UserCreateSerializer
+        elif self.action in ['update', 'partial_update']:
+            return UserUpdateSerializer
+        return UserSerializer
+    
+    def get_queryset(self):
+        """사용자 역할에 따른 쿼리셋 필터링"""
+        user = self.request.user
+        queryset = User.objects.all()
+        
+        # 관리자가 아닌 경우 자신의 정보만 조회 가능
+        if user.role not in ['admin', 'quality_manager']:
+            return queryset.filter(id=user.id)
+        
+        return queryset
+    
+    def perform_create(self, serializer):
+        """사용자 생성 시 생성자 정보 자동 설정"""
+        serializer.save()
+    
+    @action(detail=False, methods=['get'])
+    def me(self, request):
+        """현재 로그인한 사용자 정보 조회"""
+        serializer = UserSerializer(request.user)
+        return Response(serializer.data)
+    
+    @action(detail=True, methods=['post'])
+    def change_password(self, request, pk=None):
+        """사용자 비밀번호 변경"""
+        user = self.get_object()
+        
+        # 자신의 비밀번호만 변경 가능 (관리자 제외)
+        if request.user.id != user.id and request.user.role != 'admin':
+            return Response(
+                {'detail': '본인의 비밀번호만 변경할 수 있습니다.'}, 
+                status=status.HTTP_403_FORBIDDEN
+            )
+        
+        old_password = request.data.get('old_password')
+        new_password = request.data.get('new_password')
+        new_password_confirm = request.data.get('new_password_confirm')
+        
+        if not all([old_password, new_password, new_password_confirm]):
+            return Response(
+                {'detail': '모든 비밀번호 필드를 입력해주세요.'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        # 관리자가 아닌 경우 기존 비밀번호 확인
+        if request.user.role != 'admin' and not user.check_password(old_password):
+            return Response(
+                {'detail': '기존 비밀번호가 일치하지 않습니다.'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        if new_password != new_password_confirm:
+            return Response(
+                {'detail': '새 비밀번호가 일치하지 않습니다.'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        user.set_password(new_password)
+        user.save()
+        
+        return Response({'detail': '비밀번호가 성공적으로 변경되었습니다.'})
+    
+    @action(detail=False, methods=['get'])
+    def roles(self, request):
+        """사용 가능한 사용자 역할 목록"""
+        roles = [{'key': key, 'value': value} for key, value in User.ROLE_CHOICES]
+        return Response(roles)
+    
+    @action(detail=False, methods=['get'])
+    def statistics(self, request):
+        """사용자 통계 정보"""
+        if request.user.role not in ['admin', 'quality_manager']:
+            return Response(
+                {'detail': '권한이 없습니다.'}, 
+                status=status.HTTP_403_FORBIDDEN
+            )
+        
+        total_users = User.objects.count()
+        active_users = User.objects.filter(is_active=True).count()
+        role_distribution = {}
+        
+        for role_key, role_name in User.ROLE_CHOICES:
+            count = User.objects.filter(role=role_key).count()
+            role_distribution[role_name] = count
+        
+        return Response({
+            'total_users': total_users,
+            'active_users': active_users,
+            'inactive_users': total_users - active_users,
+            'role_distribution': role_distribution
+        })

--- a/backend/mes_backend/settings.py
+++ b/backend/mes_backend/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework_simplejwt',
     'corsheaders',
+    'django_filters',
     # Local apps
     'core',
 ]

--- a/backend/mes_backend/urls.py
+++ b/backend/mes_backend/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include('core.urls')),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ Django>=5.1
 djangorestframework>=3.15
 djangorestframework-simplejwt>=5.3
 django-cors-headers>=4.4
+django-filter>=23.5
 mysqlclient>=2.2
 python-decouple>=3.8
 gunicorn>=22.0


### PR DESCRIPTION
## 완료된 작업

DRF로 REST API를 전부 구현했습니다. 중간에 좀 삽질했지만 결국 다 해결했네요.

### 주요 구현 내용

- **Serializers 구현**: 8개 모델별로 CRUD 분리해서 구현
  - UserSerializer (조회/생성/수정용 각각)
  - SupplierSerializer, RawMaterialSerializer, MaterialLotSerializer
  - FinishedProductSerializer, ProductionOrderSerializer  
  - CCPSerializer, CCPLogSerializer (HACCP 불변 로그 처리)

- **ViewSets 구현**: REST API + 커스텀 액션들
  - 역할별 권한 필터링 (관리자, 품질관리자, 작업자 등)
  - 통계 API들 (/statistics, /dashboard)
  - HACCP 전용 기능들 (/compliance-report, /critical-alerts)

- **URL 라우팅**: DRF Router로 자동 URL 생성 완료

### 삽질했던 부분들

- `django-filter` 패키지 없어서 템플릿 에러 → requirements.txt 추가로 해결  
- 테스트할 때 AnonymousUser 에러 → 임시로 익명 사용자 처리했다가 다시 제거
- import 에러들 여러 개 → __init__.py 파일들 정리해서 해결

### API 엔드포인트

- `/api/users/` - 사용자 관리 (역할별 접근 제어)
- `/api/suppliers/` - 공급업체 관리 + 통계
- `/api/raw-materials/`, `/api/material-lots/` - 원자재 추적성
- `/api/finished-products/` - 완제품 관리  
- `/api/production-orders/` - 생산 오더 + 대시보드
- `/api/ccps/`, `/api/ccp-logs/` - HACCP 모니터링

브라우저에서 테스트해보니까 DRF UI도 잘 나오고 필터링도 작동합니다.

## 다음 작업

JWT 토큰 엔드포인트 추가하고 권한 시스템 좀 더 다듬어야겠어요.