### PR TITLE
fix: GitHub Actions Python 헬스체크 들여쓰기 에러 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,28 +129,7 @@ jobs:
             echo "✅ Deployment successful!"
             
             # Python urllib로 헬스체크 테스트 (더 자세한 디버깅 정보 제공)
-            docker exec mes-backend-prod python -c "
-            import urllib.request
-            import urllib.error
-            import json
-            
-            try:
-                with urllib.request.urlopen('http://localhost:8000/api/health/', timeout=10) as response:
-                    data = response.read().decode('utf-8')
-                    print('✅ API Health Check Success!')
-                    print('Status Code:', response.getcode())
-                    print('Response:', data)
-            except urllib.error.HTTPError as e:
-                print('❌ HTTP Error:', e.code, e.reason)
-                print('Response Body:', e.read().decode('utf-8') if hasattr(e, 'read') else 'No response body')
-                exit(1)
-            except urllib.error.URLError as e:
-                print('❌ URL Error:', str(e))
-                exit(1)
-            except Exception as e:
-                print('❌ Unexpected Error:', str(e))
-                exit(1)
-            "
+            docker exec mes-backend-prod python -c 'import urllib.request,urllib.error; resp=urllib.request.urlopen("http://localhost:8000/api/health/",timeout=10); print("✅ Health Check Success! Code:",resp.getcode(),"Data:",resp.read().decode("utf-8"))'
           else
             echo "❌ Deployment failed"
             exit 1


### PR DESCRIPTION
## Summary

GitHub Actions CI/CD에서 Python 헬스체크 코드의 YAML 들여쓰기 에러를 해결합니다.

## Problem



- YAML 멀티라인 문자열 내부의 Python 코드 들여쓰기로 인한 파싱 에러
- CI/CD 파이프라인에서 헬스체크 단계 실패

## Solution

- 멀티라인 Python 코드를 한 줄 형태로 변경
- 를 사용한 간단한 헬스체크 및 응답 정보 출력
- YAML 문법 에러 완전 제거

## Changes



## Test Plan

- [x] YAML 문법 검증 통과
- [ ] GitHub Actions 실행으로 헬스체크 성공 확인
- [ ] 배포 완료 후 API 응답 정보 출력 확인